### PR TITLE
Include URL in hover box; simplify figure code as well

### DIFF
--- a/college_scorecard_api.py
+++ b/college_scorecard_api.py
@@ -14,5 +14,5 @@ def _get_womens_colleges():
     """
 
     return requests.get(
-        url=f"https://api.data.gov/ed/collegescorecard/v1/schools?api_key={auth_config['API_KEY']}&school.women_only=1&fields=id,school.name,school.city,school.state,location&per_page=100",
+        url=f"https://api.data.gov/ed/collegescorecard/v1/schools?api_key={auth_config['API_KEY']}&school.women_only=1&fields=id,school.name,school.school_url,school.city,school.state,location&per_page=100",
     ).json()

--- a/main.py
+++ b/main.py
@@ -1,78 +1,66 @@
-import networkx as nx
 import plotly.graph_objects as pgo
 
 from college_scorecard_api import _get_womens_colleges
-from includes.map_functions import center_on_view
 
 
 def get_map():
 
     # COLLEGES
+
     # retrieve info about the colleges
     data = _get_womens_colleges()
     colleges = data["results"]
 
+    # fix variations in the url data
+    def add_https(url):
+        if not url.startswith("http"):
+            return f"https://{url}"
+        return url
+
     # NODES
-    # extract node geographical positions for graph
 
     ## this includes the node coordinates (longitude, latitude)
-    node_positions = {}
+    locations = {}
 
-    node_positions = {
-        college_data["school.name"]: (
-            college_data["location.lon"],
-            college_data["location.lat"],
-        )
+    locations = [
+        {
+            "name": college_data["school.name"],
+            "lat": college_data["location.lat"],
+            "lon": college_data["location.lon"],
+            "url": add_https(college_data["school.school_url"]),
+        }
         for college_data in colleges
-    }
+    ]
 
     # GRAPH
 
-    ## create a network graph
-    G = nx.Graph()
-
-    ## add nodes to graph object
-    G.add_nodes_from(node_positions.keys())
-
-    ## get longitude and latitude for node placement
-    node_longitudes = [node_positions[node][0] for node in G.nodes()]
-    node_latitudes = [node_positions[node][1] for node in G.nodes()]
-
-    ## create the node trace (trace = drawing on the map)
-    node_trace = pgo.Scattermapbox(
-        lon=node_longitudes,
-        lat=node_latitudes,
-        mode="markers+text",
-        marker=dict(size=10, color="blue"),
-        text=list(G.nodes()),  # display the server names as text
-        hoverinfo="text",
-    )
-
-    ## create the Mapbox figure
-    ## center_on_view helps to center and zoom on the bounding box
-    average_latitude, average_longitude, calculated_zoom = center_on_view(
-        node_latitudes, node_longitudes
-    )
-
     fig = pgo.Figure(
-        data=[node_trace],
-        layout=pgo.Layout(
-            title=f"College Scorecard Data: Women's Colleges in the United States",
-            showlegend=False,
-            hovermode="closest",
-            margin=dict(b=0, l=0, r=0, t=40),
-            mapbox=dict(
-                style="open-street-map",  # see https://docs.mapbox.com/mapbox-gl-js/guides/styles/
-                center=dict(
-                    lat=average_latitude,  # center on average latitude
-                    lon=average_longitude,  # center on average longitude
-                ),
-                zoom=calculated_zoom,
+        pgo.Scattermap(
+            lat=[loc["lat"] for loc in locations],
+            lon=[loc["lon"] for loc in locations],
+            mode="markers",
+            marker=pgo.scattermap.Marker(size=12),
+            customdata=[[loc["name"], loc["url"]] for loc in locations],
+            hovertemplate=(
+                "<b>%{customdata[0]}</b><br>"
+                "<a href='%{customdata[1]}' target='_blank'>Virtual Tour</a><br>"
+                "<extra></extra>"  # hides the secondary box
             ),
+            hoverlabel=dict(bgcolor="black", font_size=16),
+        )
+    )
+
+    fig.update_layout(
+        title="Women's Colleges in the United States",
+        map_style="open-street-map",
+        map=dict(
+            center=pgo.layout.map.Center(lat=39.012, lon=-98.484),
+            zoom=3,
         ),
     )
 
     # OUTPUT
+
     fig.show()
 
 


### PR DESCRIPTION
Including URL in the hover box. Required some data cleaning because some of the URLs in the data set have "https" at the beginning and some do not.

Simplified code to create the figure trace and layout, because for this mapping use case, the network graph is not needed.